### PR TITLE
Update connection handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 This module provides several nodes for interacting with Bosch Smart Home services and edge devices via the local controller API. A full documentation of the API can be found [here](https://apidocs.bosch-smarthome.com/local/).
 
 
+### Release info
+
+With the update to v0.1.7 or higher, the configuration of the SHC must be created again if you have created SHC configurations with version v0.0.6 or earlier. Therefore, please delete old SHC configurations first and recreate them after the update. 
+
+The reason for this is a change of the certificate handling. As of v0.1.7, the certificates are stored in Node-RED. This makes the whole thing more secure if Node-RED itself is properly secured. After the update you can delete the directory "/certs" in "~/.node-red". 
+
+If you encounter any problem, do not hesitate to create an issue.
+
+
 ### Features
 
 - Local network discovery of the SHC
@@ -15,7 +24,7 @@ This module provides several nodes for interacting with Bosch Smart Home service
 
 ## Device Node
 
-Events are received via long polling from the SHC as soon as any state of a service changes. Each device has several services. A device node either sends the service as a JSON object or a single state, if configured. 
+Events are received via long polling from the SHC as soon as any state of a service changes. Each device has several services. A device node either sends the service as a JSON object or a single state, if configured [https://github.com/hxmelab/node-red-contrib-bosch-shc/tree/4_FixClientCert#get-a-state](this way).
 
 ![Device node](docs/device_node.png)
 
@@ -29,14 +38,14 @@ It is also possible to send all related services of a device. Therefore, select 
 
 ### Get a specific service of a device
 
-Select a **Service** to send only objects of the specified service. As soon as any state of this service changes, the node sends a **msg** object that contains the new state. No **msg** is sent from the node if the service does not exist or is not related to the device. 
+Select a **Service** to send only objects of the specified service. As soon as any state of this service changes, the node sends a **msg** object that contains the new state. An **ENTITY_NOT_FOUND** error message is sent from the node if the service does not exist or is not related to the device. 
 
 ![Specific service](docs/device_conf_service.png)
 
 
 ### Get a state
 
-To send only a value instead of the entire service object, enter the name of the **State** in the corresponding field. No **msg** is sent from the node if the state does not exist.
+To send only a value instead of the entire service object, enter the name of the **State** in the corresponding field. The **service object** is sent from the node if the state does not exist.
 
 ![State of a service](docs/device_conf_state.png)
 
@@ -54,7 +63,7 @@ However, if the **msg.payload** matches the predefined **type** and **range** of
 | **SmokeDetectorCheck**              | boolean      | true, false    | Triggers a test alarm on this device |
 | **PowerSwitch**                     | boolean      | true, false    | Turn device on/off |
 | **PrivacyMode**                     | boolean      | true, false    | Activate/deactivate camera privacy mode |
-| **ClimateControl**                  | Number       | 5.0, 5.5, ..., 29.5, 30.0       | Set a room temperature |
+| **RoomClimateControl**                  | Number       | 5.0, 5.5, ..., 29.5, 30.0       | Set a room temperature |
 | **ShutterControl**                  | Number       | 0.000, 0.005, ..., 0.995, 1.000 | Set the level of a shutter |
 
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you encounter any problem, do not hesitate to create an issue.
 
 ## Device Node
 
-Events are received via long polling from the SHC as soon as any state of a service changes. Each device has several services. A device node either sends the service as a JSON object or a single state, if configured [https://github.com/hxmelab/node-red-contrib-bosch-shc/tree/4_FixClientCert#get-a-state](this way).
+Events are received via long polling from the SHC as soon as any state of a service changes. Each device has several services. A device node either sends the service as a JSON object or a single state, if configured [this way](https://github.com/hxmelab/node-red-contrib-bosch-shc/tree/4_FixClientCert#get-a-state).
 
 ![Device node](docs/device_node.png)
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Select a **Service** to send only objects of the specified service. As soon as a
 
 ### Get a state
 
-To send only a value instead of the entire service object, enter the name of the **State** in the corresponding field. The **service object** is sent from the node if the state does not exist.
+To send only a value instead of the entire service object, enter the name of the **State** in the corresponding field. The **service object** is sent from the node if the state does not exist or is not related to the service.
 
 ![State of a service](docs/device_conf_state.png)
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,26 @@ This module provides several nodes for interacting with Bosch Smart Home service
 
 ## Device Node
 
-A device node sends events (which are received via long polling from the controller) as soon as any state of a device changes. 
+Events are received via long polling from the SHC as soon as any state of a service changes. Each device has several services. A device node sends either the service as JSON object or a single state if configured. 
 
 ![Device node](docs/device_node.png)
 
-Each device has several services. To send all the related services of a device, select a **Device** and select **all** as a **Service**. The input field **State** can be left blank.
+
+### Get all services of a device
+
+It is also possible to send all the related services of a device. Therefore, select a **Device** and select **all** as a **Service**. The input field **State** can be left blank.
 
 ![All services](docs/device_conf_all.png)
+
+
+### Get a specific service of a device
 
 Select a **Service** to send only objects of the specified service. As soon as any state of this service changes, the node sends an **msg** object containing the new state. No **msg** is sent from the node if the service does not exist or does not refer to the device. 
 
 ![Specific service](docs/device_conf_service.png)
+
+
+### Get a state
 
 To send only a value instead of the entire service object, enter the name of the **State** in the corresponding field. No **msg** is sent from the node if the state does not exist.
 
@@ -35,6 +44,7 @@ To request an edge device any **msg** can be used. The node overwrites **msg.top
 
 ![Request a device](docs/device_node_request.png)
 
+### Set a state
 However, if the **msg.payload** matches the predefined **type** and **range** of the **service** the associated state will be updated with the specified payload value. The following services can be updated:
 
 | Service                             | Payload Type | Payload Range | Information |

--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@ This module provides several nodes for interacting with Bosch Smart Home service
 
 ## Device Node
 
-Events are received via long polling from the SHC as soon as any state of a service changes. Each device has several services. A device node sends either the service as JSON object or a single state if configured. 
+Events are received via long polling from the SHC as soon as any state of a service changes. Each device has several services. A device node either sends the service as a JSON object or a single state, if configured. 
 
 ![Device node](docs/device_node.png)
 
 
 ### Get all services of a device
 
-It is also possible to send all the related services of a device. Therefore, select a **Device** and select **all** as a **Service**. The input field **State** can be left blank.
+It is also possible to send all related services of a device. Therefore, select a **Device** and select **all** as a **Service**. The **State** input field can be left empty.
 
 ![All services](docs/device_conf_all.png)
 
 
 ### Get a specific service of a device
 
-Select a **Service** to send only objects of the specified service. As soon as any state of this service changes, the node sends an **msg** object containing the new state. No **msg** is sent from the node if the service does not exist or does not refer to the device. 
+Select a **Service** to send only objects of the specified service. As soon as any state of this service changes, the node sends a **msg** object that contains the new state. No **msg** is sent from the node if the service does not exist or is not related to the device. 
 
 ![Specific service](docs/device_conf_service.png)
 
@@ -40,12 +40,12 @@ To send only a value instead of the entire service object, enter the name of the
 
 ![State of a service](docs/device_conf_state.png)
 
-To request an edge device any **msg** can be used. The node overwrites **msg.topic** and **msg.payload** with the defined state, service, or all services as array if 'all' is selected. Then it immediately sends the **msg**.
+To request a service of a device any **msg** can be used. The device node overwrites **msg.topic** and **msg.payload** with the defined state, service, or all services as array if 'all' is selected and sends the **msg**.
 
 ![Request a device](docs/device_node_request.png)
 
 ### Set a state
-However, if the **msg.payload** matches the predefined **type** and **range** of the **service** the associated state will be updated with the specified payload value. The following services can be updated:
+However, if the **msg.payload** matches the predefined **type** and **range** of the **service**, the associated state will be updated with the specified payload value. The following services can be updated:
 
 | Service                             | Payload Type | Payload Range | Information |
 |-------------------------------------|--------------|---------------|-------------|

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This module provides several nodes for interacting with Bosch Smart Home services and edge devices via the local controller API. A full documentation of the API can be found [here](https://apidocs.bosch-smarthome.com/local/).
 
 
-### Release info
+### Release Note
 
 With the update to v0.1.7 or higher, the configuration of the SHC must be created again if you have created SHC configurations with version v0.0.6 or earlier. Therefore, please delete old SHC configurations first and recreate them after the update. 
 

--- a/nodes/shc-config.html
+++ b/nodes/shc-config.html
@@ -162,7 +162,7 @@
     <div class="form-tips"><b>Hint:</b> Please use the Bosch Smart Home App to delete a client.</div>
     <div class="form-row">
         <label for="node-config-input-clientid"><i class="fa fa-user"></i> Id</label>
-        <input type="text" id="node-config-input-clientid">
+        <input type="text" id="node-config-input-clientid" disabled>
     </div>
     <div class="form-row">
         <label for="node-config-input-clientname"><i class="fa fa-tag"></i> Name</label>
@@ -176,14 +176,14 @@
         <label for="node-config-input-state"><i class="fa fa-handshake-o"></i> State</label>
         <div style="display: inline-block; position: relative; width: 70%; height: 20px;">
             <div style="position: absolute; left: 0px; right: 40px;">
-                <input type="text" id="node-config-input-state" style="width: 100%;">
+                <input type="text" id="node-config-input-state" style="width: 100%;" disabled>
             </div>
             <a id="node-input-pair-shc" title="Register User" class="editor-button" style="position: absolute; right: 0px; top: 0px;">
             Pair</a>
         </div>
     </div>
 
-    <input type="text" id="node-config-input-key">
-    <input type="text" id="node-config-input-cert">
+    <input type="hidden" id="node-config-input-key">
+    <input type="hidden" id="node-config-input-cert">
 
 </script>

--- a/nodes/shc-config.html
+++ b/nodes/shc-config.html
@@ -26,7 +26,7 @@
             cert: {
                 type: 'password'
             },
-            private: {
+            key: {
                 type: 'password'
             }
         },
@@ -43,7 +43,7 @@
                 $.get('/shc/tls', {})
                     .done(data => {
                         RED.notify('Generated!');
-                        $('#node-config-input-private').val(data.split('|')[0]);
+                        $('#node-config-input-key').val(data.split('|')[0]);
                         $('#node-config-input-cert').val(data.split('|')[1]);
                     })
                     .fail(err => {
@@ -74,7 +74,6 @@
                 RED.notify('Searching SHCs in local network, please wait...', 'notice');
                 $.getJSON('/shc/discover', {})
                     .done(data => {
-                        console.log(data);
                         populate(data);
                         $(shcipBoxId).val(value);
                     })
@@ -108,7 +107,7 @@
                 const clientid = $('#node-config-input-clientid').val();
                 const clientname = $('#node-config-input-clientname').val();
                 const password = $('#node-config-input-password').val();
-                const key = $('#node-config-input-private').val();
+                const key = $('#node-config-input-key').val();
                 const cert = $('#node-config-input-cert').val();
                 const state = $('#node-config-input-state').val();
 
@@ -184,7 +183,7 @@
         </div>
     </div>
 
-    <input type="hidden" id="node-config-input-private">
-    <input type="hidden" id="node-config-input-cert">
+    <input type="text" id="node-config-input-key">
+    <input type="text" id="node-config-input-cert">
 
 </script>

--- a/nodes/shc-config.html
+++ b/nodes/shc-config.html
@@ -22,6 +22,12 @@
         credentials: {
             password: {
                 type: 'password'
+            },
+            cert: {
+                type: 'password'
+            },
+            private: {
+                type: 'password'
             }
         },
         label() {
@@ -32,7 +38,18 @@
             const shcipBoxText = '<input type="text" id="node-config-input-shcip" placeholder="192.168.0.10" style="width: 100%;">';
             const shcipBoxSelect = '<select id="node-config-input-shcip" style="width: 100%;" />';
 
-            if (!($('#node-config-input-clientid').val().length > 0)) {
+            if (!this.credentials.has_cert) {
+                RED.notify('Generating new client data. Please wait...');
+                $.get('/shc/tls', {})
+                    .done(data => {
+                        RED.notify('Generated!');
+                        $('#node-config-input-private').val(data.split('|')[0]);
+                        $('#node-config-input-cert').val(data.split('|')[1]);
+                    })
+                    .fail(err => {
+                        RED.notify(err.responseText, 'error');
+                    });
+
                 $.getJSON('/shc/id', {})
                     .done(data => {
                         $('#node-config-input-clientid').val(data);
@@ -87,26 +104,38 @@
             }
 
             $('#node-input-pair-shc').click(() => {
-                RED.notify('POST New Client', 'notice');
                 const shcip = $('#node-config-input-shcip').val();
                 const clientid = $('#node-config-input-clientid').val();
                 const clientname = $('#node-config-input-clientname').val();
                 const password = $('#node-config-input-password').val();
-
+                const key = $('#node-config-input-private').val();
+                const cert = $('#node-config-input-cert').val();
                 const state = $('#node-config-input-state').val();
-                if (state === 'PAIRED') {
-                    RED.notify('Client already paired', 'notice');
+
+                if (shcip.trim().length === 0 ||
+                    clientid.trim().length === 0 ||
+                    clientname.trim().length === 0) {
+                    RED.notify('Some information are missing', 'error');
                 } else {
-                    $.getJSON('/shc/client', {shcip, clientid,
-                        clientname, password})
-                        .done(data => {
-                            RED.notify('Success', 'notice');
-                            $('#node-config-input-state').val(data);
-                        })
-                        .fail(err => {
-                            RED.notify(err.responseText, 'notice');
-                            $('#node-config-input-state').val(err.responseText);
-                        });
+                    RED.notify('POST New Client', 'notice');
+                    if (state === 'PAIRED') {
+                        RED.notify('Client already paired', 'notice');
+                    } else {
+                        $.get('/shc/client', {shcip, clientid,
+                            clientname, password, key, cert})
+                            .done(data => {
+                                if (data === 'PAIRED') {
+                                    RED.notify(data, 'notice');
+                                } else {
+                                    RED.notify(data, 'error');
+                                }
+
+                                $('#node-config-input-state').val(data);
+                            })
+                            .fail(err => {
+                                RED.notify(err.responseText, 'error');
+                            });
+                    }
                 }
             });
         }
@@ -154,4 +183,8 @@
             Pair</a>
         </div>
     </div>
+
+    <input type="hidden" id="node-config-input-private">
+    <input type="hidden" id="node-config-input-cert">
+
 </script>

--- a/nodes/shc-device.html
+++ b/nodes/shc-device.html
@@ -122,18 +122,16 @@
                 }
 
                 if (shcConfig && shcConfig.state && shcConfig.state === 'PAIRED') {
-                    RED.notify('Fetching data, please wait...', 'notice');
-                    $.getJSON('/shc/devices', {shcip: shcConfig.shcip, clientid: shcConfig.clientid})
+                    RED.notify('Requesting devices, please wait...', 'notice');
+                    $.getJSON('/shc/devices', {config: shcConfig.id})
                         .done(devices => {
-                            $.getJSON('/shc/rooms', {shcip: shcConfig.shcip, clientid: shcConfig.clientid})
+                            $.getJSON('/shc/rooms', {config: shcConfig.id})
                                 .done(rooms => {
                                     populate(rooms, devices);
-                                    console.log(rooms);
                                 })
                                 .fail(err => {
                                     RED.notify(err.responseText, 'error');
                                 });
-                            console.log(devices);
                         })
                         .fail(err => {
                             RED.notify(err.responseText, 'error');
@@ -163,15 +161,17 @@
             const serviceBoxSelect = '<select id="node-input-service" style="width: 100%;" />';
 
             function lookupServices(sVal, dVal) {
-                const selectService = $('#node-input-service');
-                const optGroup = $('<optgroup label="Services"></optgroup>');
-                selectService.append(optGroup);
+                if (dVal) {
+                    const selectService = $('#node-input-service');
+                    const optGroup = $('<optgroup label="Services"></optgroup>');
+                    selectService.append(optGroup);
 
-                const sList = dVal.split('|')[3].split(',');
-                selectService.append($('<option/>').val('all').text('all'));
-                sList.forEach(element => {
-                    selectService.append($('<option/>').val(element).text(element));
-                });
+                    const sList = dVal.split('|')[3].split(',');
+                    selectService.append($('<option/>').val('all').text('all'));
+                    sList.forEach(element => {
+                        selectService.append($('<option/>').val(element).text(element));
+                    });
+                }
             }
 
             $('#node-input-lookup-service').click(() => {

--- a/nodes/shc-device.html
+++ b/nodes/shc-device.html
@@ -27,7 +27,7 @@
         outputs: 1,
         icon: 'bosch-smarthome-icon.png',
         label() {
-            return this.name || 'shc device';
+            return this.name || this.device.split('|')[0] || 'shc device';
         },
         paletteLabel: 'device',
         oneditprepare() {

--- a/nodes/shc-device.js
+++ b/nodes/shc-device.js
@@ -53,7 +53,8 @@ module.exports = function (RED) {
                     msg.topic = res.state['@type'];
                 }
 
-                if (this.state.length > 0) {
+                if (this.state.length > 0  && res.state && 
+                    res.state.hasOwnProperty(this.state)) {
                     msg.payload = res.state[this.state];
                 } else {
                     msg.payload = res;

--- a/nodes/shc-fault.html
+++ b/nodes/shc-fault.html
@@ -17,7 +17,7 @@
             }
         },
         label() {
-            return this.name || 'shc faults';
+            return this.name || (this.debug?'shc debug':'shc faults');
         },
         paletteLabel: 'faults',
         icon: 'debug.png'

--- a/nodes/shc-fault.js
+++ b/nodes/shc-fault.js
@@ -9,42 +9,19 @@ module.exports = function (RED) {
             this.name = config.name;
             this.debug = config.debug;
 
-            /**
-             * Check configuration state
-             */
             if (this.shcConfig) {
-                if (this.shcConfig.state === 'PAIRED') {
-                    this.status({fill: 'green', shape: 'dot', text: 'node-red:common.status.connected'});
-                } else {
-                    this.status({fill: 'blue', shape: 'ring', text: 'Add Client'});
-                }
-            } else {
-                this.status({fill: 'blue', shape: 'ring', text: 'Add Configuration'});
+                this.shcConfig.checkConnection(this);
+                this.shcConfig.registerListener(this);
             }
-
-            this.registerListener();
         }
 
         listener(data) {
-            if (data.error) {
-                this.status({fill: 'red', shape: 'ring', text: 'node-red:common.status.disconnected'});
-            } else {
-                this.status({fill: 'green', shape: 'dot', text: 'node-red:common.status.connected'});
-                const parsed = JSON.parse(JSON.stringify(data));
-                parsed.forEach(msg => {
-                    if (this.debug || msg.faults) {
-                        this.send({topic: 'shc-event', payload: msg});
-                    }
-                });
-            }
-        }
-
-        registerListener() {
-            if (this.shcConfig && this.shcConfig.state === 'PAIRED') {
-                this.shcConfig.addListener('shc-events', data => {
-                    this.listener(data);
-                });
-            }
+            const parsed = JSON.parse(JSON.stringify(data));
+            parsed.forEach(msg => {
+                if (this.debug || msg.faults) {
+                    this.send({topic: 'shc-event', payload: msg});
+                }
+            });
         }
     }
 

--- a/nodes/shc-logger.js
+++ b/nodes/shc-logger.js
@@ -1,21 +1,33 @@
+const DEBUG = false;
+
 module.exports = class ShcLogger {
-    fine() {
-        //console.log('fine', ...arguments);
+    fine(...args) {
+        if (DEBUG) {
+            console.log('fine', ...args);
+        }
     }
 
-    debug() {
-        //console.log('debug', ...arguments);
+    debug(...args) {
+        if (DEBUG) {
+            console.log('debug', ...args);
+        }
     }
 
-    info() {
-        //console.log('info', ...arguments);
+    info(...args) {
+        if (DEBUG) {
+            console.log('info', ...args);
+        }
     }
 
-    warn() {
-        //console.log('warn', ...arguments);
+    warn(...args) {
+        if (DEBUG) {
+            console.log('warn', ...args);
+        }
     }
 
-    error() {
-        //console.log('error', ...arguments);
+    error(...args) {
+        if (DEBUG) {
+            console.log('error', ...args);
+        }
     }
 };

--- a/nodes/shc-scenario.html
+++ b/nodes/shc-scenario.html
@@ -20,7 +20,7 @@
         outputs: 0,
         icon: 'inject.png',
         label() {
-            return this.name || 'shc scenario';
+            return this.name || this.scenario.split('|')[0] || 'shc scenario';
         },
         paletteLabel: 'scenario',
         oneditprepare() {

--- a/nodes/shc-scenario.html
+++ b/nodes/shc-scenario.html
@@ -53,12 +53,12 @@
                 }
 
                 if (shcConfig && shcConfig.state && shcConfig.state === 'PAIRED') {
-                    RED.notify('Fetching data, please wait...', 'notice');
-                    $.getJSON('/shc/scenarios', {shcip: shcConfig.shcip, cert: shcConfig.cert, private: shcConfig.private})
+                    RED.notify('Requesting scenarios, please wait...', 'notice');
+    
+                    $.getJSON('/shc/scenarios', {config: shcConfig.id})
                         .done(scenarios => {
                             populate(scenarios);
                             $(scenarioBoxId).val(value);
-                            console.log(scenarios);
                         })
                         .fail(err => {
                             RED.notify(err.responseText, 'error');

--- a/nodes/shc-scenario.html
+++ b/nodes/shc-scenario.html
@@ -54,7 +54,7 @@
 
                 if (shcConfig && shcConfig.state && shcConfig.state === 'PAIRED') {
                     RED.notify('Fetching data, please wait...', 'notice');
-                    $.getJSON('/shc/scenarios', {shcip: shcConfig.shcip, clientid: shcConfig.clientid})
+                    $.getJSON('/shc/scenarios', {shcip: shcConfig.shcip, cert: shcConfig.cert, private: shcConfig.private})
                         .done(scenarios => {
                             populate(scenarios);
                             $(scenarioBoxId).val(value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-bosch-shc",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -328,11 +328,12 @@
       }
     },
     "bosch-smart-home-bridge": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/bosch-smart-home-bridge/-/bosch-smart-home-bridge-0.0.7.tgz",
-      "integrity": "sha512-lsSd88CRZo0EpLSb+xMuZYGgpIvNkxfZHLj8wnFc9n5OZAASVPl1qy+4M86ICbxzodpuxit/iLm30DH0KyXkXw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/bosch-smart-home-bridge/-/bosch-smart-home-bridge-0.2.3.tgz",
+      "integrity": "sha512-0B/+BWoHAkOfC08M1f7zpL9atqoaEVtooXMTAd/dYWzfGkMrrr7B06Iw/pAb/16JFMJkuXxXurx5o9Wva3ltYw==",
       "requires": {
         "rxjs": "^6.5.3",
+        "selfsigned": "^1.10.7",
         "typescript": "^3.6.3",
         "uuid": "^3.3.3"
       }
@@ -3142,6 +3143,11 @@
       "resolved": "https://registry.npmjs.org/node-dns-sd/-/node-dns-sd-0.4.0.tgz",
       "integrity": "sha512-Q8VeSLyfboXzy/MzQW2x5l2z+RIiHmgrMUQX6gy5wlum1YFWHu09XIYzJazbg7CqINaubuR4QCPbO21rLmAsSw=="
     },
+    "node-forge": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
+      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -3914,6 +3920,14 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "selfsigned": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
+      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "requires": {
+        "node-forge": "0.9.0"
+      }
+    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -4516,9 +4530,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ=="
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-bosch-shc",
-  "version": "0.0.7",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2256,7 +2256,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -3019,7 +3020,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -3064,6 +3066,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -3392,15 +3395,6 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
-    "path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-      "requires": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -3583,11 +3577,6 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "progress": {
       "version": "2.0.3",
@@ -4644,14 +4633,6 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
-    },
-    "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "requires": {
-        "inherits": "2.0.3"
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-bosch-shc",
-  "version": "0.0.7",
+  "version": "0.1.7",
   "description": "Bosch Smart Home Controller (SHC) nodes for Node-Red",
   "repository": "https://github.com/hxmelab/node-red-contrib-bosch-shc",
   "main": "none",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-bosch-shc",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Bosch Smart Home Controller (SHC) nodes for Node-Red",
   "repository": "https://github.com/hxmelab/node-red-contrib-bosch-shc",
   "main": "none",
@@ -30,7 +30,7 @@
     }
   },
   "dependencies": {
-    "bosch-smart-home-bridge": "0.0.7",
+    "bosch-smart-home-bridge": "0.2.3",
     "mkdirp": "^0.5.1",
     "node-dns-sd": "0.4.0",
     "path": "^0.12.7"
@@ -51,6 +51,7 @@
       "html"
     ],
     "rules": {
+      "new-cap": 0,
       "no-template-curly-in-string": "warn",
       "camelcase": "warn",
       "capitalized-comments": 0,

--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
   },
   "dependencies": {
     "bosch-smart-home-bridge": "0.2.3",
-    "mkdirp": "^0.5.1",
-    "node-dns-sd": "0.4.0",
-    "path": "^0.12.7"
+    "node-dns-sd": "0.4.0"
   },
   "devDependencies": {
     "xo": "^0.25.3",


### PR DESCRIPTION
With the update to v0.1.7 or higher, the configuration of the SHC must be created again if you have created SHC configurations with version v0.0.6 or earlier. Therefore, please delete old SHC configurations first and recreate them after the update.

The reason for this is a change of the certificate handling. As of v0.1.7, the certificates are stored in Node-RED. This makes the whole thing more secure if Node-RED itself is properly secured. After the update you can delete the directory "/certs" in "~/.node-red".

If you encounter any problem, do not hesitate to create an issue.